### PR TITLE
add compatibility for bird2 2.0.8 and newer

### DIFF
--- a/pybird/__init__.py
+++ b/pybird/__init__.py
@@ -89,12 +89,17 @@ class PyBird:
             elif field_number == 1011:
                 # Parse the status section, which looks like:
                 # 1011-Router ID is 195.69.146.34
+                # Hostname is bird2-router
                 # Current server time is 10-01-2012 10:24:37
                 # Last reboot on 03-01-2012 12:46:40
                 # Last reconfiguration on 03-01-2012 12:46:40
                 data["router_id"] = self._parse_router_status_line(line)
 
-                line = next(line_iterator)  # skip current server time
+                line = next(line_iterator)
+                if line.lstrip().startswith("Hostname is"):
+                    data["hostname"] = line.split(" is ")[1]
+                    line = next(line_iterator)
+                # skip current server time
                 self.log.debug("PyBird: parse status: %s", line)
 
                 line = next(line_iterator)

--- a/tests/data/parse/status/bird-2.0.8.expected
+++ b/tests/data/parse/status/bird-2.0.8.expected
@@ -1,0 +1,1 @@
+{"version": "2.0.8", "router_id": "1.1.1.1", "hostname": "bird2-router", "last_reboot": "2022-01-22T09:50:55", "last_reconfiguration": "2022-01-24T22:14:37"}

--- a/tests/data/parse/status/bird-2.0.8.input
+++ b/tests/data/parse/status/bird-2.0.8.input
@@ -1,0 +1,8 @@
+0001 BIRD 2.0.8 ready.
+1000-BIRD 2.0.8
+1011-Router ID is 1.1.1.1
+ Hostname is bird2-router
+ Current server time is 2022-01-25 21:45:13.551
+ Last reboot on 2022-01-22 09:50:55.973
+ Last reconfiguration on 2022-01-24 22:14:37.341
+0013 Daemon is up and running


### PR DESCRIPTION
BIRD2 2.0.8 added a line with Hostname into the status output and the parser needed an update to handle it. With this update pybird seems to be working fine with the most recent BIRD2 version 2.0.12 as well.

All tests are passing.