### PR TITLE
small config improvements and remote_query bug fix

### DIFF
--- a/pybird/__init__.py
+++ b/pybird/__init__.py
@@ -48,9 +48,14 @@ class PyBird:
         return self._write_file(data, self.config_file)
 
     def commit_config(self):
-        return
+        return self.configure()
 
     def check_config(self):
+        """Check configuration without applying it.
+
+        Raise ValueError with the original text of the error,
+        return None for success.
+        """
         query = "configure check"
         data = self._send_query(query)
         if not self.socket_file:

--- a/pybird/__init__.py
+++ b/pybird/__init__.py
@@ -710,8 +710,8 @@ class PyBird:
         """
         cmd = f"{self.bird_cmd} -v -s {self.socket_file} '{query}'"
         res = self._remote_cmd(cmd)
-        res += "0000\n"
-        return res
+        res += b"0000\n"
+        return res.decode("utf-8")
 
     def _socket_query(self, query):
         """Open a socket to the BIRD control socket, send the query and get


### PR DESCRIPTION
On the topic of remote_query()... The support of remote queries over SSH works but should receive some improvement and/or clarification in the documentation.

In the current form the `password` argument that is accepted and saved by `PyBird.__init__()` does absolutely nothing and is not used anywhere. The SSH session established in `Popen` succeeds thanks to key-based authentication setup and working, exploits a previously authenticated session that left a control socket behind, or prompts for password which will hang any non-interactive script.

I suggest that a decision is made:
1. if a password is accepted then it should be used, but that is not something that should be particularly encouraged. It can be passed to SSH from the command line as:
    ```shell
    sshpass -p password ssh user@hostname
    ```
2. do not accept password at all and make the SSH authentication (using keys/certificates) the responsibility of the user and clearly state it in the documentation

What are your thoughts on this?