### PR TITLE
remove password arg and clarify SSH support in doc

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,32 +1,50 @@
-# Usage example
+# Usage examples
+
+## Query BIRD running locally using BIRD control socket
 
 ```py
-    >>> from pybird import PyBird
-    >>> pybird = PyBird(socket_file='/var/run/bird.ctl')
-    >>> peer_state = pybird.get_peer_status('KPN')
-    >>> peer_state['up']
-    True
-    >>> peer_state['import_updates_received']
-    4214
-    >>> peer_state['last_change']
-    datetime.datetime(2011, 6, 19, 19, 57, 0, 0)
+>>> from pybird import PyBird
+>>> pybird = PyBird(socket_file="/var/run/bird.ctl")
+>>> peer_state = pybird.get_peer_status("KPN")
+>>> peer_state["up"]
+True
+>>> peer_state["import_updates_received"]
+4214
+>>> peer_state["last_change"]
+datetime.datetime(2011, 6, 19, 19, 57, 0, 0)
 
-    >>> rejected = pybird.get_peer_prefixes_rejected('KPN')
-    >>> rejected[0]['as_path']
-    '23456 65592'
+>>> rejected = pybird.get_peer_prefixes_rejected("KPN")
+>>> rejected[0]["as_path"]
+"23456 65592"
 
-    >>> status = pybird.get_status()
-    >>> status['last_reconfiguration_time']
-    datetime.datetime(2012, 1, 3, 12, 46, 40)
-    >>> status['router_id']
-    "192.168.0.1"
+>>> status = pybird.get_status()
+>>> status["last_reconfiguration_time"]
+datetime.datetime(2012, 1, 3, 12, 46, 40)
+>>> status["router_id"]
+"192.168.0.1"
 ```
 
 You can also call ``get_peer_status()`` without a peer name, to get an array
 with all the BGP peers.
 
+## Query BIRD running remotely over SSH
 
-# Example web server with cherrypy
+> Note: pybird relies on SSH to query remote BIRD instances. A working passwordless SSH authentication
+> setup is a prerequsite for this use case. Make sure that the selected user (`bird` in the example below)
+> can log into the target server with no password prompts by using SSH keys or certificates that are
+> authorized to log in on the target server.
+>
+> Test that the command `ssh -o PasswordAuthentication=no user@hostname` logs in successfully.
+
+```py
+>>> from pybird import PyBird
+>>> pybird = PyBird(hostname="remote-bird-server.example.com", user="bird")
+>>> bird_status = pybird.get_bird_status()
+>>> bird_status
+{"version": "2.0.12", "router_id": "198.51.100.201", "hostname": "remote-bird-server", "last_reboot": datetime.datetime(2023, 1, 30, 12, 9, 45), "last_reconfiguration": datetime.datetime(2023, 1, 30,164628.599:  12, 40, 23)}
+```
+
+## Example web server with cherrypy
 
 Thanks to @martzuk
 
@@ -36,7 +54,7 @@ import json
 from pybird import PyBird
 
 class PybirdAPI(object):
-    pybird = PyBird(socket_file='/run/bird.ctl')
+    pybird = PyBird(socket_file="/run/bird.ctl")
 
     @cherrypy.expose
     def index(self):
@@ -47,7 +65,6 @@ class PybirdAPI(object):
         peer_state = self.pybird.get_peer_status()
         return json.dumps(str(peer_state))
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cherrypy.quickstart(PybirdAPI())
 ```
-

--- a/pybird/__init__.py
+++ b/pybird/__init__.py
@@ -16,7 +16,6 @@ class PyBird:
         socket_file,
         hostname=None,
         user=None,
-        password=None,
         config_file=None,
         bird_cmd=None,
     ):
@@ -25,7 +24,6 @@ class PyBird:
         self.socket_file = socket_file
         self.hostname = hostname
         self.user = user
-        self.password = password
         self.config_file = config_file
         if not bird_cmd:
             self.bird_cmd = "birdc"
@@ -672,7 +670,9 @@ class PyBird:
 
     def _remote_cmd(self, cmd, inp=None):
         to = f"{self.user}@{self.hostname}"
-        proc = Popen(["ssh", to, cmd], stdin=PIPE, stdout=PIPE)
+        proc = Popen(
+            ["ssh", "-o PasswordAuthentication=no", to, cmd], stdin=PIPE, stdout=PIPE
+        )
         res = proc.communicate(input=inp)[0]
         return res
 


### PR DESCRIPTION
As discussed in Slack, improving the remote querying capability by removing SSH password prompt and clarifying the feature in documentation.

-remove password argument from __init__
-disable PasswordAuthentication to make sure SSH never prompts for password (that is not a 100% guarantee that it won’t hang but it’s a major improvement)
-reformat examples to follow pybird coding style (quotes)